### PR TITLE
Handle material coordinate field name already in use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,13 @@ readme = readfile("README.rst", split=True)[3:]  # skip title
 requires = [
     # minimal requirements listing
     "opencmiss.utils >= 0.3",
-    "opencmiss.zinc >= 3.5"
+    "opencmiss.zinc >= 3.7"
 ]
 source_license = readfile("LICENSE")
 
 setup(
     name="dataembedder",
-    version="0.1.0",
+    version="0.2.0",
     description="Python library for embedding data and models in anatomical scaffolds using OpenCMISS-Zinc",
     long_description="\n".join(readme) + source_license,
     classifiers=[

--- a/src/dataembedder/dataembedder.py
+++ b/src/dataembedder/dataembedder.py
@@ -874,6 +874,11 @@ class DataEmbedder:
         return self._outputDataMaterialCoordinatesField
 
     def getOutputDataHostCoordinatesField(self, hostCoordinatesField: Field):
+        """
+        Get a field giving host coordinates from data material coordinates. For UI/visualisation use.
+        :param hostCoordinatesField: Field to evaluate on host.
+        :return: Field giving host coordinates on data at matching material coordinates.
+        """
         if not hostCoordinatesField:
             return None
         assert hostCoordinatesField.getFieldmodule().getRegion() == self._hostRegion
@@ -881,6 +886,8 @@ class DataEmbedder:
         with ChangeManager(hostFieldmodule):
             findMaterialMeshLocationField = hostFieldmodule.createFieldFindMeshLocation(
                 self._coordinatesArgumentField, self._materialCoordinatesField, self._hostMesh)
+            # use SEARCH_MODE_NEAREST as derivatives or minor errors may give locations outside host mesh
+            findMaterialMeshLocationField.setSearchMode(FieldFindMeshLocation.SEARCH_MODE_NEAREST)
             embeddedHostCoordinatesField =\
                 hostFieldmodule.createFieldEmbedded(hostCoordinatesField, findMaterialMeshLocationField)
             outputDataFieldmodule = self._outputDataRegion.getFieldmodule()


### PR DESCRIPTION
If material coordinate field name is in use, prefix it with "material " + ensure unique. This is most common if "coordinates" is used as the material coordinates.
Improve performance of cloning field by renaming then writing rather than replacing name in the buffer.